### PR TITLE
Iso week helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,26 @@ If you are familiar with `date-fns`, then you already know how to use `ReDate`.
 * [differenceInYears](docs/year.md#differenceinyears)
 </details>
 
+<details>
+<summary><code>ISO week</code></summary>
+
+* [endOfISOWeek](docs/ISO week.md#endofisoweek)
+* [getISOWeek](docs/ISO week.md#getisoweek)
+* [isSameISOWeek](docs/ISO week.md#issameisoweek)
+* [isThisISOWeek](docs/ISO week.md#isthisisoweek)
+* [lastDayOfISOWeek](docs/ISO week.md#lastdayofisoweek)
+* [setISOWeek](docs/ISO week.md#setisoweek)
+* [startOfISOWeek](docs/ISO week.md#startofisoweek)
+* [differenceInCalendarISOWeeks](docs/ISO week.md#differenceincalendarisoweeks)
+</details>
+
+<details>
+<summary><code>ISO year</code></summary>
+
+* [getISOWeekYear](docs/ISO year.md#getisoweekyear)
+* [startOfISOWeekYear](docs/ISO year.md#startofisoweekyear)
+</details>
+
 <!-- TOC:END -->
 
 ## Status

--- a/STATUS.md
+++ b/STATUS.md
@@ -150,14 +150,14 @@
 
 ### ISO week helpers
 
-- [ ] `endOfISOWeek`
-- [ ] `getISOWeek`
-- [ ] `isSameISOWeek`
-- [ ] `isThisISOWeek`
-- [ ] `lastDayOfISOWeek`
-- [ ] `setISOWeek`
-- [ ] `startOfISOWeek`
-- [ ] `differenceInCalendarISOWeeks`
+- [x] `endOfISOWeek`
+- [x] `getISOWeek`
+- [x] `isSameISOWeek`
+- [x] `isThisISOWeek`
+- [x] `lastDayOfISOWeek`
+- [x] `setISOWeek`
+- [x] `startOfISOWeek`
+- [x] `differenceInCalendarISOWeeks`
 
 ### ISO week-numbering year helpers
 
@@ -166,10 +166,10 @@
 - [ ] `differenceInISOWeekYears`
 - [ ] `endOfISOWeekYear`
 - [ ] `getISOWeeksInYear`
-- [ ] `getISOWeekYear`
+- [x] `getISOWeekYear`
 - [ ] `isSameISOWeekYear`
 - [ ] `isThisISOWeekYear`
 - [ ] `lastDayOfISOWeekYear`
 - [ ] `setISOWeekYear`
-- [ ] `startOfISOWeekYear`
+- [x] `startOfISOWeekYear`
 - [ ] `subISOWeekYears`

--- a/__tests__/differenceInCalendarISOWeeks_test.re
+++ b/__tests__/differenceInCalendarISOWeeks_test.re
@@ -5,15 +5,120 @@ open Js.Date;
 describe("differenceInCalendarISOWeeks", () => {
   open ExpectJs;
 
-  test("dummy", () => {
-    let date = make();
+  test("returns the number of calendar ISO weeks between the given dates", () => {
+    let fstDate =
+      makeWithYMDHM(
+        ~year=2014.,
+        ~month=6.,
+        ~date=8.,
+        ~hours=18.,
+        ~minutes=0.,
+        (),
+      );
+    let sndDate =
+      makeWithYMDHM(
+        ~year=2014.,
+        ~month=5.,
+        ~date=29.,
+        ~hours=6.,
+        ~minutes=0.,
+        (),
+      );
 
-    date |> expect |> not_ |> toEqual(date);
+    sndDate
+    |> ReDate.differenceInCalendarISOWeeks(fstDate)
+    |> expect
+    |> toEqual(2);
   });
 
-  test("dummy2", () => {
-    let date = make();
+  test(
+    "returns a negative number if the time value of the first date is smaller",
+    () => {
+    let fstDate =
+      makeWithYMDHM(
+        ~year=2014.,
+        ~month=6.,
+        ~date=8.,
+        ~hours=18.,
+        ~minutes=0.,
+        (),
+      );
+    let sndDate =
+      makeWithYMDHM(
+        ~year=2014.,
+        ~month=5.,
+        ~date=29.,
+        ~hours=6.,
+        ~minutes=0.,
+        (),
+      );
 
-    date |> expect |> not_ |> toEqual(date);
+    fstDate
+    |> ReDate.differenceInCalendarISOWeeks(sndDate)
+    |> expect
+    |> toEqual(-2);
+  });
+});
+
+describe("differenceInCalendarISOWeeks edge cases", () => {
+  open ExpectJs;
+
+  test(
+    "the difference is less than an ISO week, but the given dates are in different calendar ISO weeks",
+    () => {
+      let fstDate = makeWithYMD(~year=2014., ~month=6., ~date=7., ());
+      let sndDate = makeWithYMD(~year=2014., ~month=6., ~date=6., ());
+
+      sndDate
+      |> ReDate.differenceInCalendarISOWeeks(fstDate)
+      |> expect
+      |> toEqual(1);
+    },
+  );
+
+  test("the same for the swapped dates", () => {
+    let fstDate = makeWithYMD(~year=2014., ~month=6., ~date=6., ());
+    let sndDate = makeWithYMD(~year=2014., ~month=6., ~date=7., ());
+
+    sndDate
+    |> ReDate.differenceInCalendarISOWeeks(fstDate)
+    |> expect
+    |> toEqual(-1);
+  });
+
+  test("the days of weeks of the given dates are the same", () => {
+    let fstDate = makeWithYMD(~year=2014., ~month=6., ~date=9., ());
+    let sndDate = makeWithYMD(~year=2014., ~month=6., ~date=2., ());
+
+    sndDate
+    |> ReDate.differenceInCalendarISOWeeks(fstDate)
+    |> expect
+    |> toEqual(1);
+  });
+
+  test("the given dates are the same", () => {
+    let fstDate =
+      makeWithYMDHM(
+        ~year=2014.,
+        ~month=8.,
+        ~date=5.,
+        ~hours=0.,
+        ~minutes=0.,
+        (),
+      );
+    let sndDate =
+      makeWithYMDHM(
+        ~year=2014.,
+        ~month=8.,
+        ~date=5.,
+        ~hours=0.,
+        ~minutes=0.,
+        (),
+      );
+
+    fstDate
+    |> ReDate.differenceInCalendarISOWeeks(sndDate)
+    |> expect
+    |> toEqual(0);
   });
 });

--- a/__tests__/differenceInCalendarISOWeeks_test.re
+++ b/__tests__/differenceInCalendarISOWeeks_test.re
@@ -1,0 +1,19 @@
+open Jest;
+
+open Js.Date;
+
+describe("differenceInCalendarISOWeeks", () => {
+  open ExpectJs;
+
+  test("dummy", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+
+  test("dummy2", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+});

--- a/__tests__/endOfISOWeek_test.re
+++ b/__tests__/endOfISOWeek_test.re
@@ -1,0 +1,19 @@
+open Jest;
+
+open Js.Date;
+
+describe("endOfISOWeek", () => {
+  open ExpectJs;
+
+  test("dummy", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+
+  test("dummy2", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+});

--- a/__tests__/endOfISOWeek_test.re
+++ b/__tests__/endOfISOWeek_test.re
@@ -2,18 +2,35 @@ open Jest;
 
 open Js.Date;
 
-describe("endOfISOWeek", () => {
-  open ExpectJs;
+describe("endOfISOWeek", () =>
+  ExpectJs.(
+    test(
+      "returns the date with the time set to 23:59:59:999 and the date set to the last day of an ISO week",
+      () => {
+        let date =
+          makeWithYMDHMS(
+            ~year=2014.,
+            ~month=8.,
+            ~date=2.,
+            ~hours=11.,
+            ~minutes=55.,
+            ~seconds=0.,
+            (),
+          );
 
-  test("dummy", () => {
-    let date = make();
+        let expectedDate =
+          setHoursMSMs(
+            makeWithYMD(~year=2014., ~month=8., ~date=7., ()),
+            ~hours=23.,
+            ~minutes=59.,
+            ~seconds=59.,
+            ~milliseconds=999.,
+            (),
+          )
+          |> fromFloat;
 
-    date |> expect |> not_ |> toEqual(date);
-  });
-
-  test("dummy2", () => {
-    let date = make();
-
-    date |> expect |> not_ |> toEqual(date);
-  });
-});
+        date |> ReDate.endOfISOWeek |> expect |> toEqual(expectedDate);
+      },
+    )
+  )
+);

--- a/__tests__/getISOWeekYear_test.re
+++ b/__tests__/getISOWeekYear_test.re
@@ -1,0 +1,19 @@
+open Jest;
+
+open Js.Date;
+
+describe("getISOWeekYear", () => {
+  open ExpectJs;
+
+  test("dummy", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+
+  test("dummy2", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+});

--- a/__tests__/getISOWeekYear_test.re
+++ b/__tests__/getISOWeekYear_test.re
@@ -2,18 +2,12 @@ open Jest;
 
 open Js.Date;
 
-describe("getISOWeekYear", () => {
-  open ExpectJs;
+describe("getISOWeekYear", () =>
+  ExpectJs.(
+    test("returns the ISO week-numbering year of the given date", () => {
+      let date = makeWithYMD(~year=2007., ~month=11., ~date=31., ());
 
-  test("dummy", () => {
-    let date = make();
-
-    date |> expect |> not_ |> toEqual(date);
-  });
-
-  test("dummy2", () => {
-    let date = make();
-
-    date |> expect |> not_ |> toEqual(date);
-  });
-});
+      date |> ReDate.getISOWeekYear |> expect |> toEqual(2008);
+    })
+  )
+);

--- a/__tests__/getISOWeek_test.re
+++ b/__tests__/getISOWeek_test.re
@@ -1,0 +1,19 @@
+open Jest;
+
+open Js.Date;
+
+describe("getISOWeek", () => {
+  open ExpectJs;
+
+  test("dummy", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+
+  test("dummy2", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+});

--- a/__tests__/getISOWeek_test.re
+++ b/__tests__/getISOWeek_test.re
@@ -5,15 +5,33 @@ open Js.Date;
 describe("getISOWeek", () => {
   open ExpectJs;
 
-  test("dummy", () => {
-    let date = make();
+  test("returns the ISO week of the given date", () => {
+    let date = makeWithYMD(~year=2005., ~month=0., ~date=2., ());
 
-    date |> expect |> not_ |> toEqual(date);
+    date |> ReDate.getISOWeek |> expect |> toEqual(53);
   });
 
-  test("dummy2", () => {
-    let date = make();
+  test("returns the ISO week at 1 January 2016", () => {
+    let date = makeWithYMD(~year=2016., ~month=0., ~date=1., ());
 
-    date |> expect |> not_ |> toEqual(date);
+    date |> ReDate.getISOWeek |> expect |> toEqual(53);
+  });
+
+  test("returns the ISO week at 1 May 2016", () => {
+    let date = makeWithYMD(~year=2016., ~month=4., ~date=1., ());
+
+    date |> ReDate.getISOWeek |> expect |> toEqual(17);
+  });
+
+  test("returns the ISO week at 2 May 2016", () => {
+    let date = makeWithYMD(~year=2016., ~month=4., ~date=2., ());
+
+    date |> ReDate.getISOWeek |> expect |> toEqual(18);
+  });
+
+  test("returns the ISO week at 31 May 2016", () => {
+    let date = makeWithYMD(~year=2016., ~month=4., ~date=31., ());
+
+    date |> ReDate.getISOWeek |> expect |> toEqual(22);
   });
 });

--- a/__tests__/isSameISOWeek_test.re
+++ b/__tests__/isSameISOWeek_test.re
@@ -5,15 +5,17 @@ open Js.Date;
 describe("isSameISOWeek", () => {
   open ExpectJs;
 
-  test("dummy", () => {
-    let date = make();
+  test("returns true if the given dates have the same ISO week", () => {
+    let fstDate = makeWithYMD(~year=2014., ~month=8., ~date=1., ());
+    let sndDate = makeWithYMD(~year=2014., ~month=8., ~date=7., ());
 
-    date |> expect |> not_ |> toEqual(date);
+    sndDate |> ReDate.isSameISOWeek(fstDate) |> expect |> toEqual(true);
   });
 
-  test("dummy2", () => {
-    let date = make();
+  test("returns false if the given dates have different ISO weeks", () => {
+    let fstDate = makeWithYMD(~year=2014., ~month=8., ~date=1., ());
+    let sndDate = makeWithYMD(~year=2014., ~month=8., ~date=14., ());
 
-    date |> expect |> not_ |> toEqual(date);
+    sndDate |> ReDate.isSameISOWeek(fstDate) |> expect |> toEqual(false);
   });
 });

--- a/__tests__/isSameISOWeek_test.re
+++ b/__tests__/isSameISOWeek_test.re
@@ -1,0 +1,19 @@
+open Jest;
+
+open Js.Date;
+
+describe("isSameISOWeek", () => {
+  open ExpectJs;
+
+  test("dummy", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+
+  test("dummy2", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+});

--- a/__tests__/isThisISOWeek_test.re
+++ b/__tests__/isThisISOWeek_test.re
@@ -5,15 +5,53 @@ open Js.Date;
 describe("isThisISOWeek", () => {
   open ExpectJs;
 
-  test("dummy", () => {
-    let date = make();
+  /* Source: https://blog.blakesimpson.co.uk/page.php?id=98&title=how-to-stub-date-in-jest-tests-building-a-stubdate-helper
+        and https://github.com/facebook/jest/issues/2234#issuecomment-384884729
 
-    date |> expect |> not_ |> toEqual(date);
+        Alternative: https://github.com/mikaello/bs-jest-date-mock
+     */
+  let stubDate: Js.Date.t => unit = [%bs.raw
+    {|
+    fixedDate => {
+      let RealDate;
+
+      beforeAll(() => {
+        RealDate = Date;
+
+        Date = class extends Date {
+          constructor(...theArgs) {
+            if (theArgs.length) {
+              return new RealDate(...theArgs);
+            } else {
+              return new RealDate(fixedDate);
+            }
+          }
+        };
+      });
+
+      afterAll(() => {
+        Date = RealDate;
+      });
+    }
+    |}
+  ];
+
+  stubDate(makeWithYMDH(~year=2014., ~month=8., ~date=25., ~hours=12., ()));
+
+  test(
+    "returns true if the given date and the current date have the same ISO week",
+    () => {
+    let date = makeWithYMD(~year=2014., ~month=8., ~date=22., ());
+
+    date |> ReDate.isThisISOWeek |> expect |> toEqual(true);
   });
 
-  test("dummy2", () => {
-    let date = make();
+  test(
+    "returns false if the given date and the current date have different ISO weeks",
+    () => {
+      let date = makeWithYMD(~year=2014., ~month=8., ~date=21., ());
 
-    date |> expect |> not_ |> toEqual(date);
-  });
+      date |> ReDate.isThisISOWeek |> expect |> toEqual(false);
+    },
+  );
 });

--- a/__tests__/isThisISOWeek_test.re
+++ b/__tests__/isThisISOWeek_test.re
@@ -1,0 +1,19 @@
+open Jest;
+
+open Js.Date;
+
+describe("isThisISOWeek", () => {
+  open ExpectJs;
+
+  test("dummy", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+
+  test("dummy2", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+});

--- a/__tests__/lastDayOfISOWeek_test.re
+++ b/__tests__/lastDayOfISOWeek_test.re
@@ -2,18 +2,34 @@ open Jest;
 
 open Js.Date;
 
-describe("lastDayOfISOWeek", () => {
-  open ExpectJs;
+describe("lastDayOfISOWeek", () =>
+  ExpectJs.(
+    test(
+      "returns the date with the time set to 00:00:00 and the date set to the last day of an ISO week",
+      () => {
+        let date =
+          makeWithYMDHMS(
+            ~year=2014.,
+            ~month=8.,
+            ~date=2.,
+            ~hours=11.,
+            ~minutes=55.,
+            ~seconds=0.,
+            (),
+          );
+        let expectedDate =
+          setHoursMSMs(
+            makeWithYMD(~year=2014., ~month=8., ~date=7., ()),
+            ~hours=0.,
+            ~minutes=0.,
+            ~seconds=0.,
+            ~milliseconds=0.,
+            (),
+          )
+          |> fromFloat;
 
-  test("dummy", () => {
-    let date = make();
-
-    date |> expect |> not_ |> toEqual(date);
-  });
-
-  test("dummy2", () => {
-    let date = make();
-
-    date |> expect |> not_ |> toEqual(date);
-  });
-});
+        date |> ReDate.lastDayOfISOWeek |> expect |> toEqual(expectedDate);
+      },
+    )
+  )
+);

--- a/__tests__/lastDayOfISOWeek_test.re
+++ b/__tests__/lastDayOfISOWeek_test.re
@@ -1,0 +1,19 @@
+open Jest;
+
+open Js.Date;
+
+describe("lastDayOfISOWeek", () => {
+  open ExpectJs;
+
+  test("dummy", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+
+  test("dummy2", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+});

--- a/__tests__/setISOWeek_test.re
+++ b/__tests__/setISOWeek_test.re
@@ -1,0 +1,19 @@
+open Jest;
+
+open Js.Date;
+
+describe("setISOWeek", () => {
+  open ExpectJs;
+
+  test("dummy", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+
+  test("dummy2", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+});

--- a/__tests__/setISOWeek_test.re
+++ b/__tests__/setISOWeek_test.re
@@ -4,16 +4,31 @@ open Js.Date;
 
 describe("setISOWeek", () => {
   open ExpectJs;
+  test("sets the ISO week (first week)", () => {
+    let date = makeWithYMDH(~year=2004., ~month=7., ~date=7., ~hours=12., ());
 
-  test("dummy", () => {
-    let date = make();
+    let expectedDate =
+      makeWithYMDH(~year=2004., ~month=0., ~date=3., ~hours=12., ());
 
-    date |> expect |> not_ |> toEqual(date);
+    date |> ReDate.setISOWeek(~week=1) |> expect |> toEqual(expectedDate);
   });
 
-  test("dummy2", () => {
-    let date = make();
+  test("sets the ISO week (last week)", () => {
+    let date = makeWithYMDH(~year=2004., ~month=7., ~date=7., ~hours=12., ());
 
-    date |> expect |> not_ |> toEqual(date);
+    let expectedDate =
+      makeWithYMDH(~year=2005., ~month=0., ~date=1., ~hours=12., ());
+
+    date |> ReDate.setISOWeek(~week=53) |> expect |> toEqual(expectedDate);
+  });
+
+  test("original date should not be changed when ISO week is changed", () => {
+    let date = makeWithYMDH(~year=2004., ~month=7., ~date=7., ~hours=12., ());
+
+    let expectedDate = date |> Js.Date.getTime |> Js.Date.fromFloat;
+
+    date |> ReDate.setISOWeek(~week=53) |> ignore;
+
+    date |> expect |> toEqual(expectedDate);
   });
 });

--- a/__tests__/startOfISOWeekYear_test.re
+++ b/__tests__/startOfISOWeekYear_test.re
@@ -1,0 +1,19 @@
+open Jest;
+
+open Js.Date;
+
+describe("startOfISOWeekYear", () => {
+  open ExpectJs;
+
+  test("dummy", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+
+  test("dummy2", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+});

--- a/__tests__/startOfISOWeekYear_test.re
+++ b/__tests__/startOfISOWeekYear_test.re
@@ -5,15 +5,82 @@ open Js.Date;
 describe("startOfISOWeekYear", () => {
   open ExpectJs;
 
-  test("dummy", () => {
-    let date = make();
+  test(
+    "returns the date with the time set to 00:00:00 and the date set to the first day of an ISO year",
+    () => {
+      let date =
+        makeWithYMDHMS(
+          ~year=2009.,
+          ~month=0.,
+          ~date=1.,
+          ~hours=16.,
+          ~minutes=0.,
+          ~seconds=0.,
+          (),
+        );
 
-    date |> expect |> not_ |> toEqual(date);
+      let expectedDate =
+        setHoursMSMs(
+          makeWithYMD(~year=2008., ~month=11., ~date=29., ()),
+          ~hours=0.,
+          ~minutes=0.,
+          ~seconds=0.,
+          ~milliseconds=0.,
+          (),
+        )
+        |> fromFloat;
+
+      date |> ReDate.startOfISOWeekYear |> expect |> toEqual(expectedDate);
+    },
+  );
+
+  test("handles dates before 100 AD", () => {
+    let date =
+      setFullYearMD(
+        fromFloat(
+          setHoursMSMs(
+            fromFloat(0.),
+            ~hours=0.,
+            ~minutes=0.,
+            ~seconds=0.,
+            ~milliseconds=0.,
+            (),
+          ),
+        ),
+        ~year=9.,
+        ~month=0.,
+        ~date=1.,
+        (),
+      )
+      |> fromFloat;
+
+    let expectedDate =
+      setFullYearMD(
+        fromFloat(
+          setHoursMSMs(
+            fromFloat(0.),
+            ~hours=0.,
+            ~minutes=0.,
+            ~seconds=0.,
+            ~milliseconds=0.,
+            (),
+          ),
+        ),
+        ~year=8.,
+        ~month=11.,
+        ~date=29.,
+        (),
+      )
+      |> fromFloat;
+
+    date |> ReDate.startOfISOWeekYear |> expect |> toEqual(expectedDate);
   });
 
-  test("dummy2", () => {
-    let date = make();
+  test("correctly handles years in which 4 January is Sunday", () => {
+    let date = makeWithYMD(~year=2009., ~month=6., ~date=2., ());
 
-    date |> expect |> not_ |> toEqual(date);
+    let expectedDate = makeWithYMD(~year=2008., ~month=11., ~date=29., ());
+
+    date |> ReDate.startOfISOWeekYear |> expect |> toEqual(expectedDate);
   });
 });

--- a/__tests__/startOfISOWeek_test.re
+++ b/__tests__/startOfISOWeek_test.re
@@ -2,18 +2,35 @@ open Jest;
 
 open Js.Date;
 
-describe("startOfISOWeek", () => {
-  open ExpectJs;
+describe("startOfISOWeek", () =>
+  ExpectJs.(
+    test(
+      "returns the date with the time set to 00:00:00 and the date set to the first day of an ISO week",
+      () => {
+        let date =
+          makeWithYMDHMS(
+            ~year=2014.,
+            ~month=8.,
+            ~date=2.,
+            ~hours=11.,
+            ~minutes=55.,
+            ~seconds=0.,
+            (),
+          );
 
-  test("dummy", () => {
-    let date = make();
+        let expectedDate =
+          setHoursMSMs(
+            makeWithYMD(~year=2014., ~month=8., ~date=1., ()),
+            ~hours=0.,
+            ~minutes=0.,
+            ~seconds=0.,
+            ~milliseconds=0.,
+            (),
+          )
+          |> fromFloat;
 
-    date |> expect |> not_ |> toEqual(date);
-  });
-
-  test("dummy2", () => {
-    let date = make();
-
-    date |> expect |> not_ |> toEqual(date);
-  });
-});
+        date |> ReDate.startOfISOWeek |> expect |> toEqual(expectedDate);
+      },
+    )
+  )
+);

--- a/__tests__/startOfISOWeek_test.re
+++ b/__tests__/startOfISOWeek_test.re
@@ -1,0 +1,19 @@
+open Jest;
+
+open Js.Date;
+
+describe("startOfISOWeek", () => {
+  open ExpectJs;
+
+  test("dummy", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+
+  test("dummy2", () => {
+    let date = make();
+
+    date |> expect |> not_ |> toEqual(date);
+  });
+});

--- a/docs/ISO week.md
+++ b/docs/ISO week.md
@@ -1,0 +1,115 @@
+# ISO week helpers
+
+#### endOfISOWeek
+
+> Return the end of a week for the given date.
+>
+> ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+
+`let endOfISOWeek: Js.Date.t => Js.Date.t`
+
+```reason
+let date = Js.Date.makeWithYMDHMS(~year=2018., ~month=0., ~date=10., ~hours=16., ~minutes=50., ~seconds=12., ());
+
+date |> ReDate.endOfISOWeek;
+```
+
+#### getISOWeek
+
+> Get the ISO week of the given date.
+>
+> ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+
+`let getISOWeek: Js.Date.t => int`
+
+```reason
+let date = Js.Date.makeWithYMDHMS(~year=2005., ~month=0., ~date=2., ~hours=16., ~minutes=50., ~seconds=12., ());
+
+date |> ReDate.getISOWeek;
+```
+
+#### isSameISOWeek
+
+> Are the given dates in the same ISO week?
+>
+> ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+
+`let isSameISOWeek: (Js.Date.t, Js.Date.t) => bool`
+
+```reason
+let fstDate = Js.Date.makeWithYMDHMS(~year=2005., ~month=11., ~date=31., ~hours=16., ~minutes=50., ~seconds=12., ());
+let sndDate = Js.Date.makeWithYMDHMS(~year=2006., ~month=0., ~date=1., ~hours=10., ~minutes=15., ~seconds=55., ());
+
+fstDate |> ReDate.isSameISOWeek(sndDate);
+```
+
+#### isThisISOWeek
+
+> Is the given date in the same ISO week as the current date?
+>
+> ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+
+`let isThisISOWeek: Js.Date.t => bool`
+
+```reason
+let date = Js.Date.makeWithYMDHMS(~year=2018., ~month=0., ~date=12., ~hours=16., ~minutes=50., ~seconds=12., ());
+
+date |> ReDate.isThisISOWeek;
+```
+
+#### lastDayOfISOWeek
+
+> Return the last day of an ISO week for the given date. The result will be in the local timezone.
+>
+> ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+
+`let lastDayOfISOWeek: Js.Date.t => bool`
+
+```reason
+let date = Js.Date.makeWithYMDHMS(~year=2014., ~month=8., ~date=2., ~hours=11., ~minutes=55., ~seconds=12., ());
+
+date |> ReDate.lastDayOfISOWeek;
+```
+
+#### setISOWeek
+
+> Set the ISO week for the given date, preserving the weekday number. A new date will be returned, the original date will not be changed.
+>
+> ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+
+`let setISOWeek: (Js.Date.t, ~week: int) => Js.Date.t`
+
+```reason
+let date = Js.Date.makeWithYMD(~year=2004., ~month=7., ~date=7., ());
+
+date |> ReDate.setISOWeek(~week=53);
+```
+
+#### startOfISOWeek
+
+> Return the start of an ISO week for the given date. The result will be in the local timezone.
+>
+> ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+
+`let startOfISOWeek: Js.Date.t => Js.Date.t`
+
+```reason
+let date = Js.Date.makeWithYMDHMS(~year=2014., ~month=8., ~date=2., ~hours=11., ~minutes=55., ~seconds=0., ());
+
+date |> ReDate.startOfISOWeek;
+```
+
+#### differenceInCalendarISOWeeks
+
+> Get the number of calendar ISO weeks between the given dates.
+>
+> ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+
+`let differenceInCalendarISOWeeks: (Js.Date.t, Js.Date.t) => int`
+
+```reason
+let fstDate = Js.Date.makeWithYMDHMS(~year=2014., ~month=6., ~date=21., ~hours=23., ~minutes=59., ~seconds=59., ());
+let sndDate = Js.Date.makeWithYMDHMS(~year=2014., ~month=6., ~date=6., ~hours=0., ~minutes=0., ~seconds=0., ());
+
+fstDate |> ReDate.differenceInCalendarISOWeeks(sndDate);
+```

--- a/docs/ISO year.md
+++ b/docs/ISO year.md
@@ -1,0 +1,29 @@
+# ISO year helpers
+
+#### getISOWeekYear
+
+> Get the ISO week-numbering year of the given date, which always starts 3 days before the year's first Thursday.
+>
+> ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+
+`let getISOWeekYear: Js.Date.t => int`
+
+```reason
+let date = Js.Date.makeWithYMDHMS(~year=2018., ~month=0., ~date=12., ~hours=16., ~minutes=50., ~seconds=12., ());
+
+date |> ReDate.getISOWeekYear;
+```
+
+#### startOfISOWeekYear
+
+> Return the start of an ISO week-numbering year, which always starts 3 days before the year's first Thursday. The result will be in the local timezone.
+>
+> ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+
+`let startOfISOWeekYear: Js.Date.t => Js.Date.t`
+
+```reason
+let date = Js.Date.makeWithYMDHMS(~year=2018., ~month=0., ~date=12., ~hours=16., ~minutes=50., ~seconds=12., ());
+
+date |> ReDate.startOfISOWeekYear;
+```

--- a/scripts/generate-toc.js
+++ b/scripts/generate-toc.js
@@ -19,7 +19,7 @@ const pathToDocs = doc => `docs/${doc}.md`
 const generateAnchors = curry((doc, content) => replace(/\(\#(.+)\)/g, `(${pathToDocs(doc)}#$1)`, content))
 const capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1)
 
-const docs = ['common', 'interval', 'second', 'minute', 'hour', 'day', 'week', 'weekday', 'month', 'year']
+const docs = ['common', 'interval', 'second', 'minute', 'hour', 'day', 'week', 'weekday', 'month', 'year', 'ISO week', 'ISO year']
 const retrieveMarkdownOf = pipe(
   readDocFile,
   retrieveMarkdownTree,

--- a/src/ReDate.re
+++ b/src/ReDate.re
@@ -679,21 +679,43 @@ let eachDayOfIntervalList = interval =>
 
 /* ——[ISO Week helpers]——————— */
 
-let differenceInCalendarISOWeeks = (fst, snd) => (-1);
-
-let endOfISOWeek = date => date;
+let endOfISOWeek = date => endOfWeek(~weekStartsOn=Monday, date);
 
 let getISOWeek = date => (-1);
 
-let isSameISOWeek = (fst, snd) => true;
+let isSameISOWeek = (fst, snd) => isSameWeek(~weekStartsOn=Monday, fst, snd);
 
-let isThisISOWeek = date => true;
+let isThisISOWeek = date => isSameISOWeek(Js.Date.make(), date);
 
-let lastDayOfISOWeek = date => date;
+let lastDayOfISOWeek = date => lastDayOfWeek(~weekStartsOn=Monday, date);
 
-let setISOWeek = (date, week) => date;
+let setISOWeek = (date, ~week) => {
+  let diff = getISOWeek(date) - week |> float_of_int;
 
-let startOfISOWeek = date => date;
+  let newDate = Js.Date.getTime(date) |> Js.Date.fromFloat;
+  Js.Date.setDate(newDate, Js.Date.getDate(date) -. diff *. 7.0)
+  |> Js.Date.fromFloat;
+};
+
+let startOfISOWeek = date => startOfWeek(~weekStartsOn=Monday, date);
+
+let differenceInCalendarISOWeeks = (fst, snd) => {
+  let startOfFstISOWeek = startOfISOWeek(fst);
+  let startOfSndISOWeek = startOfISOWeek(snd);
+
+  let timestampFst =
+    Js.Date.getTime(startOfFstISOWeek)
+    -. Internal.getTimezoneOffsetInMilliseconds(startOfFstISOWeek);
+  let timestampSnd =
+    Js.Date.getTime(startOfSndISOWeek)
+    -. Internal.getTimezoneOffsetInMilliseconds(startOfSndISOWeek);
+
+  let milliseconds_in_week = 604800000.;
+  (timestampFst -. timestampSnd)
+  /. milliseconds_in_week
+  |> Js.Math.round
+  |> int_of_float;
+};
 
 /* ——[ISO Week-Numbering Year Helpers]—— */
 

--- a/src/ReDate.re
+++ b/src/ReDate.re
@@ -694,3 +694,9 @@ let lastDayOfISOWeek = date => date;
 let setISOWeek = (date, week) => date;
 
 let startOfISOWeek = date => date;
+
+/* ——[ISO Week-Numbering Year Helpers]—— */
+
+let getISOWeekYear = date => (-1); /* https://github.com/date-fns/date-fns/blob/master/src/getISOWeekYear/index.js */
+
+let startOfISOWeekYear = date => date;

--- a/src/ReDate.re
+++ b/src/ReDate.re
@@ -681,21 +681,11 @@ let eachDayOfIntervalList = interval =>
 
 let endOfISOWeek = date => endOfWeek(~weekStartsOn=Monday, date);
 
-let getISOWeek = date => (-1);
-
 let isSameISOWeek = (fst, snd) => isSameWeek(~weekStartsOn=Monday, fst, snd);
 
 let isThisISOWeek = date => isSameISOWeek(Js.Date.make(), date);
 
 let lastDayOfISOWeek = date => lastDayOfWeek(~weekStartsOn=Monday, date);
-
-let setISOWeek = (date, ~week) => {
-  let diff = getISOWeek(date) - week |> float_of_int;
-
-  let newDate = Js.Date.getTime(date) |> Js.Date.fromFloat;
-  Js.Date.setDate(newDate, Js.Date.getDate(date) -. diff *. 7.0)
-  |> Js.Date.fromFloat;
-};
 
 let startOfISOWeek = date => startOfWeek(~weekStartsOn=Monday, date);
 
@@ -761,4 +751,27 @@ let startOfISOWeekYear = date => {
     |> Internal.makeDateWithStartOfDayHours;
   let startOfThisYear = startOfISOWeek(fourthOfJanuary);
   startOfThisYear;
+};
+
+let getISOWeek = date => {
+  let millisecondsInWeek = 604800000.;
+
+  let diff =
+    Js.Date.getTime(startOfISOWeek(date))
+    -. Js.Date.getTime(startOfISOWeekYear(date));
+
+  /*
+   Round the number of days to the nearest integer
+   because the number of milliseconds in a week is not constant
+   (e.g. it's different in the week of the daylight saving time clock shift)
+   */
+  Js.Math.round(diff /. millisecondsInWeek) +. 1. |> int_of_float;
+};
+
+let setISOWeek = (date, ~week) => {
+  let diff = getISOWeek(date) - week |> float_of_int;
+
+  let newDate = Js.Date.getTime(date) |> Js.Date.fromFloat;
+  Js.Date.setDate(newDate, Js.Date.getDate(date) -. diff *. 7.0)
+  |> Js.Date.fromFloat;
 };

--- a/src/ReDate.re
+++ b/src/ReDate.re
@@ -676,3 +676,21 @@ let eachDayOfIntervalList = interval =>
       interval |> makeIntervalDay,
     )
   );
+
+/* ——[ISO Week helpers]——————— */
+
+let differenceInCalendarISOWeeks = (fst, snd) => (-1);
+
+let endOfISOWeek = date => date;
+
+let getISOWeek = date => (-1);
+
+let isSameISOWeek = (fst, snd) => true;
+
+let isThisISOWeek = date => true;
+
+let lastDayOfISOWeek = date => date;
+
+let setISOWeek = (date, week) => date;
+
+let startOfISOWeek = date => date;

--- a/src/ReDate.re
+++ b/src/ReDate.re
@@ -679,15 +679,15 @@ let eachDayOfIntervalList = interval =>
 
 /* ——[ISO Week helpers]——————— */
 
-let endOfISOWeek = date => endOfWeek(~weekStartsOn=Monday, date);
+let endOfISOWeek = endOfWeek(~weekStartsOn=Monday);
 
-let isSameISOWeek = (fst, snd) => isSameWeek(~weekStartsOn=Monday, fst, snd);
+let isSameISOWeek = isSameWeek(~weekStartsOn=Monday);
 
 let isThisISOWeek = date => isSameISOWeek(Js.Date.make(), date);
 
-let lastDayOfISOWeek = date => lastDayOfWeek(~weekStartsOn=Monday, date);
+let lastDayOfISOWeek = lastDayOfWeek(~weekStartsOn=Monday);
 
-let startOfISOWeek = date => startOfWeek(~weekStartsOn=Monday, date);
+let startOfISOWeek = startOfWeek(~weekStartsOn=Monday);
 
 let differenceInCalendarISOWeeks = (fst, snd) => {
   let startOfFstISOWeek = startOfISOWeek(fst);
@@ -700,9 +700,8 @@ let differenceInCalendarISOWeeks = (fst, snd) => {
     Js.Date.getTime(startOfSndISOWeek)
     -. Internal.getTimezoneOffsetInMilliseconds(startOfSndISOWeek);
 
-  let milliseconds_in_week = 604800000.;
   (timestampFst -. timestampSnd)
-  /. milliseconds_in_week
+  /. float_of_int(Milliseconds.week)
   |> Js.Math.round
   |> int_of_float;
 };
@@ -754,8 +753,6 @@ let startOfISOWeekYear = date => {
 };
 
 let getISOWeek = date => {
-  let millisecondsInWeek = 604800000.;
-
   let diff =
     Js.Date.getTime(startOfISOWeek(date))
     -. Js.Date.getTime(startOfISOWeekYear(date));
@@ -765,7 +762,9 @@ let getISOWeek = date => {
    because the number of milliseconds in a week is not constant
    (e.g. it's different in the week of the daylight saving time clock shift)
    */
-  Js.Math.round(diff /. millisecondsInWeek) +. 1. |> int_of_float;
+  Js.Math.round(diff /. float_of_int(Milliseconds.week))
+  +. 1.
+  |> int_of_float;
 };
 
 let setISOWeek = (date, ~week) => {

--- a/src/ReDate.re
+++ b/src/ReDate.re
@@ -719,6 +719,46 @@ let differenceInCalendarISOWeeks = (fst, snd) => {
 
 /* ——[ISO Week-Numbering Year Helpers]—— */
 
-let getISOWeekYear = date => (-1); /* https://github.com/date-fns/date-fns/blob/master/src/getISOWeekYear/index.js */
+let getISOWeekYear = date => {
+  let year = Js.Date.getFullYear(date);
 
-let startOfISOWeekYear = date => date;
+  let fourthOfJanuaryOfNextYear =
+    Js.Date.setFullYearMD(
+      Js.Date.fromFloat(0.),
+      ~year=year +. 1.,
+      ~month=0.,
+      ~date=4.,
+      (),
+    )
+    |> Js.Date.fromFloat
+    |> Internal.makeDateWithStartOfDayHours;
+  let startOfNextYear = fourthOfJanuaryOfNextYear |> startOfISOWeek;
+
+  let fourthOfJanuaryOfThisYear =
+    Js.Date.setFullYear(
+      fourthOfJanuaryOfNextYear |> Js.Date.getTime |> Js.Date.fromFloat,
+      year,
+    )
+    |> Js.Date.fromFloat;
+  let startOfThisYear = fourthOfJanuaryOfThisYear |> startOfISOWeek;
+
+  if (Js.Date.getTime(date) >= Js.Date.getTime(startOfNextYear)) {
+    year +. 1. |> int_of_float;
+  } else if (Js.Date.getTime(date) >= Js.Date.getTime(startOfThisYear)) {
+    year |> int_of_float;
+  } else {
+    year -. 1. |> int_of_float;
+  };
+};
+
+let startOfISOWeekYear = date => {
+  let year = getISOWeekYear(date) |> float_of_int;
+
+  let fourthOfJanuary = Js.Date.fromFloat(0.);
+  let fourthOfJanuary =
+    Js.Date.setFullYearMD(fourthOfJanuary, ~year, ~month=0., ~date=4., ())
+    |> Js.Date.fromFloat
+    |> Internal.makeDateWithStartOfDayHours;
+  let startOfThisYear = startOfISOWeek(fourthOfJanuary);
+  startOfThisYear;
+};

--- a/src/ReDate.rei
+++ b/src/ReDate.rei
@@ -238,3 +238,9 @@ let lastDayOfISOWeek: Js.Date.t => Js.Date.t;
 let setISOWeek: (Js.Date.t, int) => Js.Date.t;
 
 let startOfISOWeek: Js.Date.t => Js.Date.t;
+
+/* ——[ISO Week-Numbering Year Helpers]—— */
+
+let getISOWeekYear: Js.Date.t => int;
+
+let startOfISOWeekYear: Js.Date.t => Js.Date.t;

--- a/src/ReDate.rei
+++ b/src/ReDate.rei
@@ -221,9 +221,7 @@ let eachDayOfIntervalArray: interval => array(Js.Date.t);
 
 let eachDayOfIntervalList: interval => list(Js.Date.t);
 
-/* ——[ISO Week helpers]——————— */
-
-let differenceInCalendarISOWeeks: (Js.Date.t, Js.Date.t) => int;
+/* ——[ISO Week helpers]——————————— */
 
 let endOfISOWeek: Js.Date.t => Js.Date.t;
 
@@ -235,9 +233,11 @@ let isThisISOWeek: Js.Date.t => bool;
 
 let lastDayOfISOWeek: Js.Date.t => Js.Date.t;
 
-let setISOWeek: (Js.Date.t, int) => Js.Date.t;
+let setISOWeek: (Js.Date.t, ~week: int) => Js.Date.t;
 
 let startOfISOWeek: Js.Date.t => Js.Date.t;
+
+let differenceInCalendarISOWeeks: (Js.Date.t, Js.Date.t) => int;
 
 /* ——[ISO Week-Numbering Year Helpers]—— */
 

--- a/src/ReDate.rei
+++ b/src/ReDate.rei
@@ -220,3 +220,21 @@ let getOverlappingDaysInIntervals: (interval, interval) => int;
 let eachDayOfIntervalArray: interval => array(Js.Date.t);
 
 let eachDayOfIntervalList: interval => list(Js.Date.t);
+
+/* ——[ISO Week helpers]——————— */
+
+let differenceInCalendarISOWeeks: (Js.Date.t, Js.Date.t) => int;
+
+let endOfISOWeek: Js.Date.t => Js.Date.t;
+
+let getISOWeek: Js.Date.t => int;
+
+let isSameISOWeek: (Js.Date.t, Js.Date.t) => bool;
+
+let isThisISOWeek: Js.Date.t => bool;
+
+let lastDayOfISOWeek: Js.Date.t => Js.Date.t;
+
+let setISOWeek: (Js.Date.t, int) => Js.Date.t;
+
+let startOfISOWeek: Js.Date.t => Js.Date.t;


### PR DESCRIPTION
Here are implementations for all ISO week helper functions, and a couple of ISO Week-numbering year helpers that I needed to implement the week helpers.

I have tried to adhere to the way you have previously done, and I think I have full test coverage. The tests are mainly copied from corresponding tests in `date-fns`. The implementation is also done with the same logic as in `date-fns`. 