### PR TITLE
reversed args and some tests

### DIFF
--- a/__tests__/setDate_test.res
+++ b/__tests__/setDate_test.res
@@ -1,0 +1,16 @@
+open Jest
+
+open Js.Date
+
+describe("setDate", () => {
+  open ExpectJs
+
+  test("sets the date of the given date", () => {
+    let date = makeWithYMD(~year=2018., ~month=0., ~date=1., ())
+    let expectedDate = makeWithYMD(~year=2018., ~month=0., ~date=20., ())
+
+    let result = date->ReDate.setDate(20.)
+
+    result |> expect |> toEqual(expectedDate)
+  })
+})

--- a/__tests__/setHours_test.res
+++ b/__tests__/setHours_test.res
@@ -1,0 +1,16 @@
+open Jest
+
+open Js.Date
+
+describe("setHours", () => {
+  open ExpectJs
+
+  test("sets the hours of the given date", () => {
+    let date = makeWithYMDH(~year=2018., ~month=0., ~date=1., ~hours=18., ())
+    let expectedDate = makeWithYMDH(~year=2018., ~month=0., ~date=1., ~hours=9., ())
+
+    let result = date->ReDate.setHours(9.)
+
+    result |> expect |> toEqual(expectedDate)
+  })
+})

--- a/__tests__/setMinutes_test.res
+++ b/__tests__/setMinutes_test.res
@@ -1,0 +1,16 @@
+open Jest
+
+open Js.Date
+
+describe("setMinutes", () => {
+  open ExpectJs
+
+  test("sets the minutes of the given date", () => {
+    let date = makeWithYMDHM(~year=2018., ~month=0., ~date=1., ~hours=18., ~minutes=1., ())
+    let expectedDate = makeWithYMDHM(~year=2018., ~month=0., ~date=1., ~hours=18., ~minutes=30., ())
+
+    let result = date->ReDate.setMinutes(30.)
+
+    result |> expect |> toEqual(expectedDate)
+  })
+})

--- a/__tests__/setMonth_test.res
+++ b/__tests__/setMonth_test.res
@@ -1,0 +1,16 @@
+open Jest
+
+open Js.Date
+
+describe("setMonth", () => {
+  open ExpectJs
+
+  test("sets the month of the given date", () => {
+    let date = makeWithYMD(~year=2018., ~month=0., ~date=1., ())
+    let expectedDate = makeWithYMD(~year=2018., ~month=10., ~date=1., ())
+
+    let result = date->ReDate.setMonth(10.)
+
+    result |> expect |> toEqual(expectedDate)
+  })
+})

--- a/__tests__/setSeconds_test.res
+++ b/__tests__/setSeconds_test.res
@@ -1,0 +1,32 @@
+open Jest
+
+open Js.Date
+
+describe("setSeconds", () => {
+  open ExpectJs
+
+  test("sets the minutes of the given date", () => {
+    let date = makeWithYMDHMS(
+      ~year=2018.,
+      ~month=0.,
+      ~date=1.,
+      ~hours=18.,
+      ~minutes=1.,
+      ~seconds=0.,
+      (),
+    )
+    let expectedDate = makeWithYMDHMS(
+      ~year=2018.,
+      ~month=0.,
+      ~date=1.,
+      ~hours=18.,
+      ~minutes=1.,
+      ~seconds=50.,
+      (),
+    )
+
+    let result = date->ReDate.setSeconds(50.)
+
+    result |> expect |> toEqual(expectedDate)
+  })
+})

--- a/__tests__/setYear_test.res
+++ b/__tests__/setYear_test.res
@@ -1,0 +1,16 @@
+open Jest
+
+open Js.Date
+
+describe("setYear", () => {
+  open ExpectJs
+
+  test("sets the year of the given date", () => {
+    let date = makeWithYM(~year=2018., ~month=0., ())
+    let expectedDate = makeWithYM(~year=2042., ~month=0., ())
+
+    let result = date->ReDate.setYear(2042.)
+
+    result |> expect |> toEqual(expectedDate)
+  })
+})

--- a/__tests__/subMonths_test.res
+++ b/__tests__/subMonths_test.res
@@ -9,13 +9,17 @@ describe("subMonths", () => {
     let date = makeWithYMD(~year=2018., ~month=1., ~date=1., ())
     let expectedDate = makeWithYMD(~year=2018., ~month=0., ~date=1., ())
 
-    date |> ReDate.subMonths(1.) |> expect |> toEqual(expectedDate)
+    let result = date->ReDate.subMonths(1.)
+
+    result |> expect |> toEqual(expectedDate)
   })
 
   test("subtracts 30 months", () => {
     let date = makeWithYMD(~year=2020., ~month=11., ~date=1., ())
     let expectedDate = makeWithYMD(~year=2018., ~month=5., ~date=1., ())
 
-    date |> ReDate.subMonths(30.) |> expect |> toEqual(expectedDate)
+    let result = date->ReDate.subMonths(30.)
+
+    result |> expect |> toEqual(expectedDate)
   })
 })

--- a/src/ReDate_month.res
+++ b/src/ReDate_month.res
@@ -14,7 +14,7 @@ let addMonths = (date, months) => {
   Js.Date.makeWithYMD(~year, ~month, ~date, ())
 }
 
-let subMonths = (months, date) => addMonths(date, -.months)
+let subMonths = (date, months) => addMonths(date, -.months)
 
 let getMonth = Js.Date.getMonth
 

--- a/src/ReDate_second.res
+++ b/src/ReDate_second.res
@@ -10,7 +10,7 @@ let addSeconds = (date, seconds) => {
 
 let subSeconds = (date, seconds) => addSeconds(date, -.seconds)
 
-let setSeconds = (seconds, date) => {
+let setSeconds = (date, seconds) => {
   let date = Js.Date.setSeconds(makeDate(date), seconds)
   Js.Date.fromFloat(date)
 }


### PR DESCRIPTION
Hey there,

While writing wrappers for ReDate methods for use in my hybrid TS/ReScript codebase I noticed that both `setSeconds` and `subMonths` had reversed args positions from the rest of their respective methods. I went ahead and swapped them to be inline and fixed the  associated tests for `subMonths` while adding very simple tests for the rest of the `setX` methods.

